### PR TITLE
Enabling MetaMask security code scanner

### DIFF
--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -1,0 +1,42 @@
+name: 'MetaMask Security Code Scanner'
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+
+jobs:
+  run-security-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: MetaMask Security Code Scanner
+        uses: MetaMask/Security-Code-Scanner@main
+        with:
+          repo: ${{ github.repository }}
+          paths_ignored: |
+            .storybook/
+            '**/__snapshots__/'
+            '**/*.snap'
+            '**/*.stories.js'
+            '**/*.stories.tsx'
+            '**/*.test.browser.ts*'
+            '**/*.test.js*'
+            '**/*.test.ts*'
+            '**/fixtures/'
+            '**/jest.config.js'
+            '**/jest.environment.js'
+            '**/mocks/'
+            '**/test*/'
+            docs/
+            e2e/
+            merged-packages/
+            node_modules
+            storybook/
+            test*/
+          rules_excluded: example
+          project_metrics_token: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
+          slack_webhook: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}


### PR DESCRIPTION

## Automated PR
This is automated Pull Request by Application Security team.
Please reach out to `@mm-application-security` slack if you have any feedback or comments.

## Required Action

Prior to merging this pull request, please ensure the following has been completed:

- [ ] The lines specifying `branches` correctly specifies this repository's default branch (usually `main`).
- [ ] Any paths you would like to ignore have been added to the `paths_ignored` configuration option (see [setup](https://github.com/MetaMask/Security-Code-Scanner/blob/main/README.md#setup))
- [ ] Any existing CodeQL configuration has been disabled.

## What is the Security Code Scanner?

This pull request enables the [MetaMask Security Code Scanner](https://github.com/metamask/Security-Code-Scanner/) GitHub Action. This action runs on each pull request, and will flag potential vulnerabilities as a review comment. It will also scan this repository's default branch, and log any findings in this repository's [Code Scanning Alerts Tab](https://github.com/metamask/juice-shop/security/code-scanning).

<img width="500" alt="Screenshot 2024-02-12 at 9 19 05 PM" src="https://github.com/MetaMask/Appsec-Proving-Grounds/blob/main/img/scanning-alert.png?raw=true">

The action itself runs various static analysis engines behind the scenes. Currently, it is only running GitHub's CodeQL engine. For this reason, we recommend disabling any existing CodeQL configuration your repository may have.

## How do I interact with the tool?

Every finding raised by the Security Code Scanner will present context behind the potential vulnerability identified, and allow the developer to fix, or dismiss it.

The finding will automatically be dismissed by pushing a commit that fixes the identified issue, or by manually dismissing the alert using the button in GitHub's UI. If dismissing an alert manually, please add any additional context surrounding the reason for dismissal, as this informs our decision to disable, or improve any poor performing rules.

 <img width="983" alt="Screenshot 2024-02-12 at 8 41 46 PM" src="https://github.com/MetaMask/Appsec-Proving-Grounds/blob/main/img/dismissing-alert.png?raw=true">

For more configuration options, please review the tool's [README](https://github.com/MetaMask/Security-Code-Scanner/blob/main/README.md).
For any additional questions, please reach out to `@mm-application-security` slack.
